### PR TITLE
fix version requirement to use correct syntax

### DIFF
--- a/lib/RTSP/Proxy/Session.pm
+++ b/lib/RTSP/Proxy/Session.pm
@@ -5,7 +5,7 @@ our $VERSION = '0.02';
 use Moose;
 
 use Carp qw/croak/;
-use RTSP::Client '0.03';
+use RTSP::Client 0.03;
 
 has id => (
     is => 'rw',


### PR DESCRIPTION
Version numbers on a use line need to be unquoted to be handled properly. When they are quoted, they are passed in import instead. Part versions of perl ignored these arguments, but future versions are intending to throw errors for arguments given to an undefined import method.